### PR TITLE
change packagename to fix naming collision

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.keshavkaul.sketchview">
 
 </manifest>
   


### PR DESCRIPTION
This should fix an issue with naming collisions while building.